### PR TITLE
feat: 新增 跨环境开发；fix: 修复一些问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "a calendar for wechat miniprogram",
     "main": "index.js",
     "scripts": {
-        "build": "NODE_ENV=production gulp build",
-        "dev": "NODE_ENV=development gulp dev",
+        "build": "cross-env NODE_ENV=production gulp build",
+        "dev": "cross-env NODE_ENV=development gulp dev",
         "test": "npx jest"
     },
     "keywords": [
@@ -28,6 +28,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.14.7",
+        "cross-env": "^7.0.3",
         "gulp": "^4.0.2",
         "gulp-babel": "^8.0.0",
         "gulp-clean": "^0.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -672,16 +672,18 @@ Component({
             const currTab = this.data.currTab
             const currMonth = this.data.months[currTab]
             if (currMonth.year == year && currMonth.month == month) {
-                this._yearPanelShow = false
-                this.setData({
-                    yearPanelShow: false
-                })
+                this.onCloseYearsPanel()
             } else {
-                this._yearPanelShow = false
-                this.setData({ yearPanelShow: false })
+                this.onCloseYearsPanel()
                 this.refreshMonthsPanelByDate({ year, month, day: 1 })
                 this.bindDateChange(this._selDay)
             }
+        },
+
+        // 关闭 years 面板
+        onCloseYearsPanel() {
+            this._yearPanelShow = false
+            this.setData({ yearPanelShow: false })
         },
         /** YEAR PANEL */
 

--- a/src/index.wxml
+++ b/src/index.wxml
@@ -142,7 +142,7 @@
         <!-- Calendar Panel Year Start -->
         <view class="wx-calendar-years {{ yearPanelShow ? 'show' : '' }}">
             <view class="wx-calendar-years-bar">
-                <view class="wx-calendar-years-bar-title" data-info="{{ yearMs[currYearsTab].lunar_year }}">
+                <view class="wx-calendar-years-bar-title" data-info="{{ yearMs[currYearsTab].lunar_year }}" catchtap="onCloseYearsPanel" >
                     <text >{{ yearMs[currYearsTab].year }}</text><text class="wx-calendar-cn-text margin-left">年</text>
                 </view>
             </view>

--- a/src/index.wxs
+++ b/src/index.wxs
@@ -275,6 +275,11 @@ var handleYearPanelShow = function(e, ins) {
         }
         ins.callMethod('handleYearPanelShow')
         ins.callMethod('toggleView', { state: 1 })
+
+        var schedules = ins.selectAllComponents('.wx-calendar-panel-solar-schedules')
+        for (var i = 0; i < schedules.length; i++) {
+            schedules[i].removeClass('show')
+        }
     }
 }
 


### PR DESCRIPTION
- `feat`: 使用 cross-env 兼容 windows 开发；
- `fix`: 修复 点击顶部 year 栏拉起 Year Panel 时，再次点击无法收起的问题。用户可能只是不小心点到，发现没有收起的按钮，会有点不友好，所以就在year panel 的 title 上也加上监听按钮，监听点击后可以收起。
- `fix`: 修复 在完整展示“月”的模式下（`viewState` 为 3 时），点击 year 栏拉起 Year Panel 时，schedule 不会收起的问题。 