### PR TITLE
fix(calendar): weekOrder 函数中存在无限递归bug

### DIFF
--- a/src/interface/calendar.ts
+++ b/src/interface/calendar.ts
@@ -484,7 +484,7 @@ const weekOrder = (date: CalendarDay, weekstart = 0) => {
   start.setDate(start.getDate() - ((start.getDay() + 7 - weekstart) % 7));
   // 作为上一年的最后一周
   if (curr < start) return weekOrder({ year: year - 1, month: 12, day: 31 }, weekstart);
-  
+  /** 计算相隔天数 */
   const days = Math.floor((+curr - +start) / 86400000) + 1;
   return Math.ceil(days / 7);
 };

--- a/src/interface/calendar.ts
+++ b/src/interface/calendar.ts
@@ -483,8 +483,8 @@ const weekOrder = (date: CalendarDay, weekstart = 0) => {
   const start = new Date(year, 0, 4);
   start.setDate(start.getDate() - ((start.getDay() + 7 - weekstart) % 7));
   // 作为上一年的最后一周
-  if (curr < start) return weekOrder({ year, month: 1, day: 0 }, weekstart);
-  /** 计算相隔天数 */
+  if (curr < start) return weekOrder({ year: year - 1, month: 12, day: 31 }, weekstart);
+  
   const days = Math.floor((+curr - +start) / 86400000) + 1;
   return Math.ceil(days / 7);
 };


### PR DESCRIPTION
### 问题分析：
当 curr < start 时（即当前日期早于该年1月4号所在周的周首日），函数会递归调用：
```weekOrder({ year, month: 1, day: 0 }, weekstart)```

### 关键缺陷：
传入参数 `{ year, month: 1, day: 0 }`
`new Date(year, 0, 0)` 会被 JavaScript 解释为 year 年 1月 0日 = year-1 年 12月 31日
但 year 参数没有减1！
导致每次递归都传入相同的参数
形成无限递归循环 → 栈溢出

### 触发场景：
当日历初始化为周视图（view="week"）时
调用 getDateInfo(checked, weekstart, isWeekView)
如果 isWeekView 为 true，会调用 weekOrder(date, weekstart)
如果日期恰好早于该年1月4号所在周，触发无限递归


### 常见报错
```
Uncaught (in promise) RangeError: Maximum call stack size exceeded
```
```
TypeError: Cannot read property 'year' of null
```